### PR TITLE
DM-43901: Add section for documenteer-guide setup for future transition

### DIFF
--- a/doc/development-guidelines/documentation-guide.rst
+++ b/doc/development-guidelines/documentation-guide.rst
@@ -28,7 +28,47 @@ The following steps will explain how to use it.
 Once those three questions are answered then a brand new doc folder will be added to the CSC.
 Inside of the files, there are comments that explain how to fill out each section in detail.
 
+Conf.py
+=======
+The conf.py file is a Sphinx configuration file that contains information on Sphinx should build the site as well as any extensions that should be loaded. 
+You can find the template conf.py at https://github.com/lsst-ts/cookiecutter_tssw_csc_doc/blob/90c866162936f4d31d5fb1e1684e17a75128765d/%7B%7Bcookiecutter.doc%7D%7D/conf.py.
+Documenteer is a tool that provides pre-made Sphinx configurations for 3 different purposes that SQRE provides the project.
+
+1. pipelines
+2. guide
+3. technote
+
+It also provides several project extensions for the RSP packages.
+All documentation is available at https://documenteer.lsst.io.
+
+..
+    Remove with DM-44045.
+
+The template does not yet provide compatibility with documenteer 1.0 and above.
+See the :ref:`development-guidelines/documentation-guide:Documenteer configuration` section for how to accomplish this.
+
 Publishing lsst.io Site
 =======================
 
 This functionality is included in the DevelopPipeline for the Jenkins Shared Library.
+
+Documenteer Configuration
+=========================
+
+..
+    Remove with DM-44045.
+
+.. note:: The following section is for older doc folders to move the new system provided by documenteer 1.0 and above.
+    In the future, this section will be removed once the doc template is updated.
+
+Create a documenteer.toml file using https://documenteer.lsst.io/guides/toml-reference.html as reference material.
+A basic documenteer.toml example is provided below.
+
+.. literalinclude:: ./documenteer.toml.example
+
+You also need to change first line in conf.py to import from the guide config with
+
+.. code:: python
+
+    from documenteer.conf.guide import *
+

--- a/doc/development-guidelines/documenteer.toml.example
+++ b/doc/development-guidelines/documenteer.toml.example
@@ -1,0 +1,21 @@
+# This template contains enough information for documenteer to build
+
+[project]
+# The title of the index page.
+title = ""
+# Copyright information displayed on the footer of each page
+copyright = "2019-2024 Association of Universities for Research in Astronomy, Inc. (AURA)"
+
+[project.python]
+# pyproject.toml package name, fills out unseen metadata
+package = ""
+documentation_url_key = "documentation"
+github_url_key = "source_code"
+
+[sphinx]
+extensions = ["sphinx-jsonschema"]
+
+[sphinx.intersphinx.projects]
+ts-xml = "https://ts-xml.lsst.io"
+salobj = "https://ts-salobj.lsst.io"
+python = "https://docs.python.org/3.11/"


### PR DESCRIPTION
This PR adds a section for setting up documenteer to use the guide configuration in preparation for DM's transition for documenteer 2.0 where the pipeline config will be removed.
The pipeline config will be replaced by the guide config and so in anticipation of this change, we should start preparing our CSCs as this process is planned for the summer.

